### PR TITLE
Update domain to geosphere.at

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@
 
 [![Project Maintenance][maintenance-shield]][user_profile]
 
-Python library to read 10 min weather data from ZAMG
+Python library to read 10 min weather data from Geosphere Austria former ZAMG
 
 ## About
 
-This package allows you to read the weather data from weather stations of ZAMG weather service.
-ZAMG is the Zentralanstalt für Meteorologie und Geodynamik in Austria.
+This package allows you to read the weather data from weather stations of Geosphere Austria weather service.
+Geosphere Austria joins Zentralanstalt für Meteorologie und Geodynamik (ZAMG) and the Geologische Bundesanstalt (GBA)
+since 1st January 2023.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -103,4 +103,4 @@ Code template to read dataset API was mainly taken from [@LuisTheOne](https://gi
 [releases]: https://github.com/killer0071234/python-zamg/releases
 [user_profile]: https://github.com/killer0071234
 [zamg_api_cli_client]: https://github.com/LuisThe0ne/zamg-api-cli-client
-[dataset_api_doc]: https://dataset.api.hub.zamg.ac.at/v1/docs/index.html
+[dataset_api_doc]: https://github.com/Geosphere-Austria/dataset-api-docs

--- a/src/zamg/zamg.py
+++ b/src/zamg/zamg.py
@@ -27,10 +27,10 @@ class ZamgData:
     """The class for handling the data retrieval."""
 
     dataset_metadata_url: str = (
-        "https://dataset.api.hub.zamg.ac.at/v1/station/current/tawes-v1-10min/metadata"
+        "https://dataset.api.hub.geosphere.at/v1/station/current/tawes-v1-10min/metadata"
     )
     """API url to fetch possible stations and parameters."""
-    dataset_data_url: str = "https://dataset.api.hub.zamg.ac.at/v1/station/current/tawes-v1-10min?parameters="
+    dataset_data_url: str = "https://dataset.api.hub.geosphere.at/v1/station/current/tawes-v1-10min?parameters="
     """API url to fetch current conditions of a weather station."""
     request_timeout: float = 8.0
     headers = {

--- a/src/zamg/zamg.py
+++ b/src/zamg/zamg.py
@@ -26,9 +26,7 @@ CLIENT_AGENT = f"Python/{version_info[0]}.{version_info[1]} +https://github.com/
 class ZamgData:
     """The class for handling the data retrieval."""
 
-    dataset_metadata_url: str = (
-        "https://dataset.api.hub.geosphere.at/v1/station/current/tawes-v1-10min/metadata"
-    )
+    dataset_metadata_url: str = "https://dataset.api.hub.geosphere.at/v1/station/current/tawes-v1-10min/metadata"
     """API url to fetch possible stations and parameters."""
     dataset_data_url: str = "https://dataset.api.hub.geosphere.at/v1/station/current/tawes-v1-10min?parameters="
     """API url to fetch current conditions of a weather station."""

--- a/tests/test_zamg.py
+++ b/tests/test_zamg.py
@@ -41,7 +41,7 @@ async def test_update_fixed_param(fix_data) -> None:
 async def test_update_fail(aresponses) -> None:
     """Test update function."""
     aresponses.add(
-        "dataset.api.hub.zamg.ac.at",
+        "dataset.api.hub.geosphere.at",
         "/v1/station/current/tawes-v1-10min",
         "GET",
         aresponses.Response(text="error", status=500),
@@ -57,7 +57,7 @@ async def test_update_fail(aresponses) -> None:
 async def test_update_fail_1(aresponses) -> None:
     """Test update function."""
     aresponses.add(
-        "dataset.api.hub.zamg.ac.at",
+        "dataset.api.hub.geosphere.at",
         "/v1/station/current/tawes-v1-10min",
         "GET",
         aresponses.Response(text="error", status=500),
@@ -73,7 +73,7 @@ async def test_update_fail_1(aresponses) -> None:
 async def test_update_fail_2(aresponses) -> None:
     """Test update function."""
     aresponses.add(
-        "dataset.api.hub.zamg.ac.at",
+        "dataset.api.hub.geosphere.at",
         "/v1/station/current/tawes-v1-10min",
         "GET",
         aresponses.Response(text="{}", status=200),
@@ -89,7 +89,7 @@ async def test_update_fail_2(aresponses) -> None:
 async def test_update_fail_3(aresponses) -> None:
     """Test update function."""
     aresponses.add(
-        "dataset.api.hub.zamg.ac.at",
+        "dataset.api.hub.geosphere.at",
         "/v1/station/current/tawes-v1-10min",
         "GET",
         aresponses.Response(text="{}", status=200),
@@ -135,7 +135,7 @@ async def test_properties_pre_loaded(fix_metadata) -> None:
 async def test_properties_fail_1(aresponses) -> None:
     """Test getting properties."""
     aresponses.add(
-        "dataset.api.hub.zamg.ac.at",
+        "dataset.api.hub.geosphere.at",
         "/v1/station/current/tawes-v1-10min/metadata",
         "GET",
         response=aresponses.Response(text="", status=404),
@@ -160,7 +160,7 @@ async def test_properties_fail_2(aresponses) -> None:
 async def test_properties_fail_3(aresponses) -> None:
     """Test getting properties."""
     aresponses.add(
-        "dataset.api.hub.zamg.ac.at",
+        "dataset.api.hub.geosphere.at",
         "/v1/station/current/tawes-v1-10min/metadata",
         "GET",
         response=aresponses.Response(text=""),
@@ -236,7 +236,7 @@ async def test_closest_station(fix_metadata) -> None:
 async def test_closest_station_not_found(aresponses) -> None:
     """Test getting closest station."""
     aresponses.add(
-        "dataset.api.hub.zamg.ac.at",
+        "dataset.api.hub.geosphere.at",
         "/v1/station/current/tawes-v1-10min/metadata",
         "GET",
         response={"title": "TAWES", "stations": []},
@@ -305,7 +305,7 @@ def fix_metadata(aresponses):
         .read_text(encoding="utf-8")
     )
     aresponses.add(
-        "dataset.api.hub.zamg.ac.at",
+        "dataset.api.hub.geosphere.at",
         "/v1/station/current/tawes-v1-10min/metadata",
         "GET",
         response=data_metadata,
@@ -321,7 +321,7 @@ def fix_data(aresponses):
         .read_text(encoding="utf-8")
     )
     aresponses.add(
-        "dataset.api.hub.zamg.ac.at",
+        "dataset.api.hub.geosphere.at",
         "/v1/station/current/tawes-v1-10min",
         "GET",
         response=data_station,


### PR DESCRIPTION
## Scope

* Changed calls to Geosphere Austria's Datahub from `dataset.api.hub.zamg.ac.at` to `dataset.api.hub.geosphere.at`
* Changed dataset-api docs link in the README to point to the Github Repo

## Code quality

* Tests passed
* pre-commit hooks were run

## Additional notes

Due to the very small nature of this change, I did little no additional checks. From our side nothing else should have changed, so this should be a safe change. However, please mind that operational issues can occur even with small changes such as this one. If any problem arises, please open an issue at https://github.com/Geosphere-Austria/dataset-api-docs