### PR TITLE
Keep aiohttp session open

### DIFF
--- a/src/zamg/__init__.py
+++ b/src/zamg/__init__.py
@@ -1,6 +1,6 @@
 """Asynchronous Python client for ZAMG weather data."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from .exceptions import ZamgApiError
 from .exceptions import ZamgError


### PR DESCRIPTION
Keep a existing (or external) created aiohttp session open on error.

fixes #253 