### PR TITLE
Loosen async-timeout requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8"
 aiohttp = ">=3.8.0"
-async-timeout = "4.0.3"
+async-timeout = "^4.0.3"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^2.1.5"


### PR DESCRIPTION
Pinning a specific version of `async-timeout` (`==4.0.3`) makes it difficult for downstream libraries to update when a new version is released. Loosen it to allow other compatible versions as well.