### PR TITLE
Add get_station_location property and corresponding tests

### DIFF
--- a/control.py
+++ b/control.py
@@ -17,6 +17,8 @@ async def main():
             data = await zamg.closest_station(46.99, 15.499)
             # set closest station as default one to read
             zamg.set_default_station(data)
+            # print station location of the closest station
+            print("get_station_location = " + str(zamg.get_station_location))
             print("closest_station = " + str(zamg.get_station_name) + " / " + str(data))
             # print list with all possible parameters
             print(f"Possible station parameters: {zamg.get_all_parameters()}")

--- a/forecast.py
+++ b/forecast.py
@@ -13,15 +13,17 @@ async def main():
         async with src.zamg.zamg.ZamgData() as zamg:
             # option to disable verify of ssl check
             zamg.verify_ssl = False
-
-            # data = await zamg.zamg_stations()
-
+            # trying to read GeoSphere Austria station id of the closest station
+            data = await zamg.closest_station(46.99, 15.499)
+            # set closest station as default one to read
+            zamg.set_default_station(data)
             # print(f"forecast_metadata: {zamg.forecast_metadata}")
             # print(f"get_forecast_all_parameters: {zamg.get_forecast_all_parameters()}")
 
             data = await zamg.get_forecast("46.99,15.499", current_only=True)
             print(f"get_forecast(current_only=True): {data}")
-            data = await zamg.get_forecast("46.99,15.499", current_only=False)
+            # get forecast for the default station (closest station) with all parameters
+            data = await zamg.get_forecast(current_only=False)
             print(f"get_forecast(current_only=False): {data}")
 
             return

--- a/src/zamg/zamg.py
+++ b/src/zamg/zamg.py
@@ -91,8 +91,8 @@ class ZamgData:
                 for timestamp in timestamps
             ]
 
-            now_utc = datetime.utcnow().replace(
-                tzinfo=zoneinfo.ZoneInfo("UTC"), second=0, microsecond=0
+            now_utc = datetime.now(zoneinfo.ZoneInfo("UTC")).replace(
+                second=0, microsecond=0
             )
             index = next(
                 (
@@ -141,8 +141,8 @@ class ZamgData:
                 for timestamp in timestamps
             ]
 
-            now_utc = datetime.utcnow().replace(
-                tzinfo=zoneinfo.ZoneInfo("UTC"), second=0, microsecond=0
+            now_utc = datetime.now(zoneinfo.ZoneInfo("UTC")).replace(
+                second=0, microsecond=0
             )
             index = next(
                 (
@@ -398,7 +398,7 @@ class ZamgData:
             return None
         if self.last_update and (
             self.last_update + timedelta(minutes=5)
-            > datetime.utcnow().replace(tzinfo=zoneinfo.ZoneInfo("UTC"))
+            > datetime.now(zoneinfo.ZoneInfo("UTC"))
         ):
             return (
                 self.data
@@ -457,7 +457,7 @@ class ZamgData:
         """Return a list of all current observations of the default station id."""
         if self.last_forecast_update and (
             self.last_forecast_update + timedelta(minutes=5)
-            > datetime.utcnow().replace(tzinfo=zoneinfo.ZoneInfo("UTC"))
+            > datetime.now(zoneinfo.ZoneInfo("UTC"))
         ):
             if current_only:
                 return self.get_forecast_current()
@@ -474,10 +474,9 @@ class ZamgData:
                 forecast_params = (
                     self.forecast_parameters or "t2m,rr_acc,u10m,v10m,tcc,rh2m"
                 )
-                lat_lon = (
-                    lat_lon
-                    or f"{self.get_station_location[0]},{self.get_station_location[1]}"
-                )
+                if lat_lon is None:
+                    station_lat, station_lon = self.get_station_location
+                    lat_lon = f"{station_lat},{station_lon}"
                 response = await self.session.get(
                     url=self.forecast_url + forecast_params + "&lat_lon=" + lat_lon,
                     allow_redirects=True,
@@ -490,8 +489,8 @@ class ZamgData:
 
                 self.data_forecast = json.loads(contents)
                 self._timestamp_forecast = (
-                    datetime.utcnow()
-                    .replace(tzinfo=zoneinfo.ZoneInfo("UTC"), second=0, microsecond=0)
+                    datetime.now(zoneinfo.ZoneInfo("UTC"))
+                    .replace(second=0, microsecond=0)
                     .strftime("%Y-%m-%dT%H:%M%z")
                 )
                 if current_only:

--- a/src/zamg/zamg.py
+++ b/src/zamg/zamg.py
@@ -365,6 +365,15 @@ class ZamgData:
         except (KeyError, TypeError) as exc:
             raise ZamgStationUnknownError(exc) from exc
 
+    @property
+    def get_station_location(self) -> tuple[float, float]:
+        """Return the current Station location as (lat, lon)."""
+        try:
+            lat, lon, _ = self._stations[self._station_id]
+            return (lat, lon)
+        except (KeyError, TypeError) as exc:
+            raise ZamgStationUnknownError(exc) from exc
+
     def set_default_station(self, station_id: str):
         """Set the default station_id for update()."""
         self._station_id = station_id
@@ -443,7 +452,7 @@ class ZamgData:
             raise ZamgNoDataError(exc) from exc
 
     async def get_forecast(
-        self, lat_lon: str, current_only: bool = False
+        self, lat_lon: str | None = None, current_only: bool = False
     ) -> dict | None:
         """Return a list of all current observations of the default station id."""
         if self.last_forecast_update and (
@@ -464,6 +473,10 @@ class ZamgData:
             async with async_timeout.timeout(self.request_timeout):
                 forecast_params = (
                     self.forecast_parameters or "t2m,rr_acc,u10m,v10m,tcc,rh2m"
+                )
+                lat_lon = (
+                    lat_lon
+                    or f"{self.get_station_location[0]},{self.get_station_location[1]}"
                 )
                 response = await self.session.get(
                     url=self.forecast_url + forecast_params + "&lat_lon=" + lat_lon,

--- a/tests/test_zamg.py
+++ b/tests/test_zamg.py
@@ -332,43 +332,45 @@ async def test_get_station_location_unknown(fix_metadata) -> None:
 async def test_get_forecast_uses_station_location(aresponses) -> None:
     """Test get_forecast uses default station location when lat_lon isn't provided."""
 
-    zamg = ZamgData()
-    zamg._stations = {
-        "11240": (46.980555555555554, 15.44, "GRAZ-THALERHOF-FLUGHAFEN")
-    }
-    zamg.set_default_station("11240")
+    async with ZamgData() as zamg:
+        zamg._stations = {
+            "11240": (46.980555555555554, 15.44, "GRAZ-THALERHOF-FLUGHAFEN")
+        }
+        zamg.set_default_station("11240")
 
-    now_utc = datetime.utcnow().replace(
-        tzinfo=zoneinfo.ZoneInfo("UTC"), second=0, microsecond=0
-    )
-    timestamp = now_utc.strftime("%Y-%m-%dT%H:%M%z")
+        now_utc = datetime.utcnow().replace(
+            tzinfo=zoneinfo.ZoneInfo("UTC"), second=0, microsecond=0
+        )
+        timestamp = now_utc.strftime("%Y-%m-%dT%H:%M%z")
 
-    aresponses.add(
-        "dataset.api.hub.geosphere.at",
-        "/v1/timeseries/forecast/nwp-v1-1h-2500m?parameters=t2m,rr_acc,u10m,v10m,tcc,rh2m&lat_lon=46.980555555555554,15.44",
-        "GET",
-        response={
-            "reference_time": timestamp,
-            "timestamps": [timestamp],
-            "features": [
-                {
-                    "properties": {
-                        "parameters": {
-                            "t2m": {"data": [0.0]},
-                            "rh2m": {"data": [0.0]},
-                            "u10m": {"data": [0.0]},
-                            "v10m": {"data": [0.0]},
-                            "tcc": {"data": [0.0]},
-                            "rr_acc": {"data": [0.0]},
+        aresponses.add(
+            "dataset.api.hub.geosphere.at",
+            "/v1/timeseries/forecast/nwp-v1-1h-2500m",
+            "GET",
+            response={
+                "reference_time": timestamp,
+                "timestamps": [timestamp],
+                "features": [
+                    {
+                        "properties": {
+                            "parameters": {
+                                "t2m": {"data": [0.0]},
+                                "rh2m": {"data": [0.0]},
+                                "u10m": {"data": [0.0]},
+                                "v10m": {"data": [0.0]},
+                                "tcc": {"data": [0.0]},
+                                "rr_acc": {"data": [0.0]},
+                            }
                         }
                     }
-                }
-            ],
-        },
-    )
+                ],
+            },
+        )
 
-    result = await zamg.get_forecast(current_only=True)
-    assert result["timestamp"] == timestamp
+        result = await zamg.get_forecast(current_only=True)
+        assert result["timestamp"] == timestamp
+
+
 @pytest.mark.asyncio
 async def test_last_update(fix_data, fix_metadata) -> None:
     """Test getting last_update."""

--- a/tests/test_zamg.py
+++ b/tests/test_zamg.py
@@ -329,6 +329,47 @@ async def test_get_station_location_unknown(fix_metadata) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_forecast_uses_station_location(aresponses) -> None:
+    """Test get_forecast uses default station location when lat_lon isn't provided."""
+
+    zamg = ZamgData()
+    zamg._stations = {
+        "11240": (46.980555555555554, 15.44, "GRAZ-THALERHOF-FLUGHAFEN")
+    }
+    zamg.set_default_station("11240")
+
+    now_utc = datetime.utcnow().replace(
+        tzinfo=zoneinfo.ZoneInfo("UTC"), second=0, microsecond=0
+    )
+    timestamp = now_utc.strftime("%Y-%m-%dT%H:%M%z")
+
+    aresponses.add(
+        "dataset.api.hub.geosphere.at",
+        "/v1/timeseries/forecast/nwp-v1-1h-2500m?parameters=t2m,rr_acc,u10m,v10m,tcc,rh2m&lat_lon=46.980555555555554,15.44",
+        "GET",
+        response={
+            "reference_time": timestamp,
+            "timestamps": [timestamp],
+            "features": [
+                {
+                    "properties": {
+                        "parameters": {
+                            "t2m": {"data": [0.0]},
+                            "rh2m": {"data": [0.0]},
+                            "u10m": {"data": [0.0]},
+                            "v10m": {"data": [0.0]},
+                            "tcc": {"data": [0.0]},
+                            "rr_acc": {"data": [0.0]},
+                        }
+                    }
+                }
+            ],
+        },
+    )
+
+    result = await zamg.get_forecast(current_only=True)
+    assert result["timestamp"] == timestamp
+@pytest.mark.asyncio
 async def test_last_update(fix_data, fix_metadata) -> None:
     """Test getting last_update."""
 

--- a/tests/test_zamg.py
+++ b/tests/test_zamg.py
@@ -309,6 +309,26 @@ async def test_get_station_name_unknown(fix_metadata) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_station_location(fix_metadata) -> None:
+    """Test getting get_station_location."""
+
+    zamg = ZamgData()
+    await zamg.zamg_stations()
+    zamg.set_default_station("11240")
+    assert zamg.get_station_location == (46.980555555555554, 15.44)
+
+
+@pytest.mark.asyncio
+async def test_get_station_location_unknown(fix_metadata) -> None:
+    """Test getting get_station_location."""
+
+    zamg = ZamgData()
+    await zamg.zamg_stations()
+    with pytest.raises(ZamgStationUnknownError):
+        _ = zamg.get_station_location
+
+
+@pytest.mark.asyncio
 async def test_last_update(fix_data, fix_metadata) -> None:
     """Test getting last_update."""
 


### PR DESCRIPTION
- Implemented get_station_location method in ZamgData to return the current station's latitude and longitude.
- Updated main functions in control.py and forecast.py to utilize the new method.
- Added tests for get_station_location and handling of unknown station scenarios in test_zamg.py.